### PR TITLE
Makes js-lint invoke bundled prettier cli rather than target repo's prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,5 @@
     "tsx": "^3.12.7",
     "typedoc": "^0.24.8",
     "typescript": "^5.1.6"
-  },
-  "peerDependencies": {
-    "eslint": ">=9.0.0"
   }
 }


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
This PR replaces the current way js-lint invokes prettier by invoking its local version rather than trying to look for prettier on the target repo's PATH

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #20 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Replace the way prettier is currently invoked by making it rely on local dependency first before trying to fallback on the target repo's PATH.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
