### PR TITLE
Make js-lint use local prettier config instead of target repo's prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,13 @@
   "trailingComma": "all",
   "singleQuote": true,
   "printWidth": 80,
-  "tabWidth": 2
+  "tabWidth": 2,
+  "overrides": [
+    {
+      "files": ["*.md", "*.mdx"],
+      "options": {
+        "proseWrap": "always"
+      }
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # js-lint
 
-A batteries-included, TypeScript-aware linting CLI and ESLint flat config bundle for use in Matrix AI JavaScript/TypeScript projects.
+A batteries-included, TypeScript-aware linting CLI and ESLint flat config bundle
+for use in Matrix AI JavaScript/TypeScript projects.
 
-- Type-aware linting powered by `@typescript-eslint` using one or more `tsconfig.json` files
-- Built-in support for React, Tailwind, JSX a11y, Prettier, and Matrix AI custom rules
+- Type-aware linting powered by `@typescript-eslint` using one or more
+  `tsconfig.json` files
+- Built-in support for React, Tailwind, JSX a11y, Prettier, and Matrix AI custom
+  rules
 - Supports Prettier formatting for Markdown and ShellCheck for shell scripts
 - Single command to lint JavaScript/TypeScript, Markdown, and shell scripts
-- Customizable via `matrixai-lint-config.json` and extensible with your own ESLint config
+- Customizable via `matrixai-lint-config.json` and extensible with your own
+  ESLint config
 - CLI options to override config and enable auto-fix
 
 ## Installation
@@ -46,7 +50,8 @@ matrixai-lint --config ./eslint.config.js --fix
 
 ### TypeScript Support
 
-The linter is TypeScript-aware and requires a `tsconfig.json` to determine which files to lint and how to parse them.
+The linter is TypeScript-aware and requires a `tsconfig.json` to determine which
+files to lint and how to parse them.
 
 By default:
 
@@ -55,7 +60,9 @@ By default:
 
 ### Working with multiple tsconfigs
 
-If your project uses more than one `tsconfig.json` or doesn't have one at the root, you can configure the linter using a `matrixai-lint-config.json` file at the root:
+If your project uses more than one `tsconfig.json` or doesn't have one at the
+root, you can configure the linter using a `matrixai-lint-config.json` file at
+the root:
 
 ```json
 {
@@ -69,7 +76,8 @@ If your project uses more than one `tsconfig.json` or doesn't have one at the ro
 | `tsconfigPaths` | `string[]` | One or more paths to `tsconfig.json` files                                               |
 | `forceInclude`  | `string[]` | Paths to always include, even if excluded by tsconfig (must be included by at least one) |
 
-> ⚠ If a path in `forceInclude` is not included in any of the `tsconfigPaths`, TypeScript will throw a parsing error.
+> ⚠ If a path in `forceInclude` is not included in any of the `tsconfigPaths`,
+> TypeScript will throw a parsing error.
 
 ### ESLint Config Override
 
@@ -100,14 +108,14 @@ Valid config filenames:
 
 ```ts
 // eslint.config.js
-import matrixai from '@matrixai/lint/config';
+import matrixai from "@matrixai/lint/config";
 
 export default [
   ...matrixai,
   {
     rules: {
-      '@typescript-eslint/no-explicit-any': 'error',
-      'no-console': 'off',
+      "@typescript-eslint/no-explicit-any": "error",
+      "no-console": "off",
     },
   },
 ];

--- a/src/bin/lint.ts
+++ b/src/bin/lint.ts
@@ -6,12 +6,19 @@ import process from 'node:process';
 import childProcess from 'node:child_process';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
+import url from 'node:url';
 import { Command } from 'commander';
 import * as utils from '../utils.js';
 
 const platform = os.platform();
 const program = new Command();
 const DEFAULT_SHELLCHECK_SEARCH_ROOTS = ['./src', './scripts', './tests'];
+
+const dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const builtinPrettierCfg = path.resolve(
+  dirname,
+  '../configs/prettier.config.mjs',
+);
 
 program
   .name('matrixai-lint')
@@ -139,7 +146,16 @@ async function main(argv = process.argv) {
     return;
   }
 
-  const prettierArgs = [fix ? '--write' : '--check', ...markdownFiles];
+  const prettierArgs = [
+    '--config',
+    builtinPrettierCfg,
+    '--config-precedence',
+    'cli-override',
+    '--no-editorconfig',
+    fix ? '--write' : '--check',
+    ...markdownFiles,
+  ];
+
   console.error('Running prettier:');
 
   const require = createRequire(import.meta.url);

--- a/src/configs/js.ts
+++ b/src/configs/js.ts
@@ -1,14 +1,14 @@
-import type { EcmaVersion } from '@typescript-eslint/utils/ts-eslint';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import globals from 'globals';
-import _import from 'eslint-plugin-import';
-import js from '@eslint/js';
-import tsParser from '@typescript-eslint/parser';
-import { FlatCompat } from '@eslint/eslintrc';
-import { fixupPluginRules } from '@eslint/compat';
-import matrixaiPlugin from '../plugins/eslint-plugin-matrixai.js';
-import { resolveMatrixConfig } from '../utils.js';
+import type { EcmaVersion } from "@typescript-eslint/utils/ts-eslint";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import globals from "globals";
+import _import from "eslint-plugin-import";
+import js from "@eslint/js";
+import tsParser from "@typescript-eslint/parser";
+import { FlatCompat } from "@eslint/eslintrc";
+import { fixupPluginRules } from "@eslint/compat";
+import matrixaiPlugin from "../plugins/eslint-plugin-matrixai.js";
+import { resolveMatrixConfig } from "../utils.js";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -21,23 +21,23 @@ const compat = new FlatCompat({
 
 const config = [
   ...compat.extends(
-    'eslint:recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
-    'plugin:react/recommended',
-    'plugin:react-hooks/recommended',
-    'plugin:tailwindcss/recommended',
-    'plugin:jsx-a11y/recommended',
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:tailwindcss/recommended",
+    "plugin:jsx-a11y/recommended",
   ),
   {
     plugins: {
       import: fixupPluginRules(_import),
-      '@matrixai': matrixaiPlugin,
+      "@matrixai": matrixaiPlugin,
     },
 
     settings: {
       react: {
-        version: 'detect',
+        version: "detect",
       },
     },
 
@@ -50,210 +50,210 @@ const config = [
       },
       parser: tsParser,
       ecmaVersion: 5 as EcmaVersion,
-      sourceType: 'module',
+      sourceType: "module",
       parserOptions: {
         project: resolveMatrixConfig().tsconfigPaths,
       },
     },
     rules: {
       // MatrixAI rules
-      '@matrixai/no-aliased-imports': [
-        'error',
+      "@matrixai/no-aliased-imports": [
+        "error",
         {
-          aliases: [{ prefix: '#', target: 'src' }],
-          includeFolders: ['src'],
+          aliases: [{ prefix: "#", target: "src" }],
+          includeFolders: ["src"],
           autoFix: true,
         },
       ],
 
       // React rules
-      'react/react-in-jsx-scope': 0,
-      'react/no-unknown-property': 'off',
-      'react/button-has-type': 'error',
-      'react/no-unused-prop-types': 'error',
-      'react/jsx-pascal-case': 'error',
-      'react/jsx-no-script-url': 'error',
-      'react/no-children-prop': 'error',
-      'react/no-danger': 'error',
-      'react/no-danger-with-children': 'error',
-      'react/no-unstable-nested-components': ['error', { allowAsProps: true }],
-      'react/jsx-fragments': 'error',
-      'react/destructuring-assignment': [
-        'error',
-        'always',
-        { destructureInSignature: 'always' },
+      "react/react-in-jsx-scope": 0,
+      "react/no-unknown-property": "off",
+      "react/button-has-type": "error",
+      "react/no-unused-prop-types": "error",
+      "react/jsx-pascal-case": "error",
+      "react/jsx-no-script-url": "error",
+      "react/no-children-prop": "error",
+      "react/no-danger": "error",
+      "react/no-danger-with-children": "error",
+      "react/no-unstable-nested-components": ["error", { allowAsProps: true }],
+      "react/jsx-fragments": "error",
+      "react/destructuring-assignment": [
+        "error",
+        "always",
+        { destructureInSignature: "always" },
       ],
-      'react/jsx-no-leaked-render': ['error', { validStrategies: ['ternary'] }],
-      'react/function-component-definition': [
-        'warn',
-        { namedComponents: 'arrow-function' },
+      "react/jsx-no-leaked-render": ["error", { validStrategies: ["ternary"] }],
+      "react/function-component-definition": [
+        "warn",
+        { namedComponents: "arrow-function" },
       ],
-      'react/jsx-key': [
-        'error',
+      "react/jsx-key": [
+        "error",
         {
           checkFragmentShorthand: true,
           checkKeyMustBeforeSpread: true,
           warnOnDuplicates: true,
         },
       ],
-      'react/jsx-no-useless-fragment': 'warn',
-      'react/jsx-curly-brace-presence': 'warn',
-      'react/no-typos': 'warn',
-      'react/display-name': 'warn',
-      'react/jsx-sort-props': 'warn',
-      'react/jsx-one-expression-per-line': 'off',
-      'react/prop-types': 'off',
+      "react/jsx-no-useless-fragment": "warn",
+      "react/jsx-curly-brace-presence": "warn",
+      "react/no-typos": "warn",
+      "react/display-name": "warn",
+      "react/jsx-sort-props": "warn",
+      "react/jsx-one-expression-per-line": "off",
+      "react/prop-types": "off",
 
-      '@typescript-eslint/no-floating-promises': [
-        'error',
+      "@typescript-eslint/no-floating-promises": [
+        "error",
         {
           ignoreVoid: true,
           ignoreIIFE: true,
         },
       ],
-      '@typescript-eslint/no-misused-promises': [
-        'error',
+      "@typescript-eslint/no-misused-promises": [
+        "error",
         {
           checksVoidReturn: false,
         },
       ],
-      '@typescript-eslint/await-thenable': ['error'],
-      '@typescript-eslint/no-empty-object-type': 'off',
-      '@typescript-eslint/no-unsafe-declaration-merging': 'off',
+      "@typescript-eslint/await-thenable": ["error"],
+      "@typescript-eslint/no-empty-object-type": "off",
+      "@typescript-eslint/no-unsafe-declaration-merging": "off",
 
-      'linebreak-style': ['error', 'unix'],
-      'no-empty': 1,
-      'no-useless-catch': 1,
-      'no-prototype-builtins': 1,
-      'no-constant-condition': 0,
-      'no-useless-escape': 0,
-      'no-console': 'error',
-      'no-restricted-globals': [
-        'error',
+      "linebreak-style": ["error", "unix"],
+      "no-empty": 1,
+      "no-useless-catch": 1,
+      "no-prototype-builtins": 1,
+      "no-constant-condition": 0,
+      "no-useless-escape": 0,
+      "no-console": "error",
+      "no-restricted-globals": [
+        "error",
         {
-          name: 'global',
-          message: 'Use `globalThis` instead',
+          name: "global",
+          message: "Use `globalThis` instead",
         },
         {
-          name: 'window',
-          message: 'Use `globalThis` instead',
+          name: "window",
+          message: "Use `globalThis` instead",
         },
       ],
-      'prefer-rest-params': 0,
-      'require-yield': 0,
-      eqeqeq: ['error', 'smart'],
-      'spaced-comment': [
-        'warn',
-        'always',
+      "prefer-rest-params": 0,
+      "require-yield": 0,
+      eqeqeq: ["error", "smart"],
+      "spaced-comment": [
+        "warn",
+        "always",
         {
           line: {
-            exceptions: ['-'],
+            exceptions: ["-"],
           },
           block: {
-            exceptions: ['*'],
+            exceptions: ["*"],
           },
-          markers: ['/'],
+          markers: ["/"],
         },
       ],
-      'capitalized-comments': [
-        'warn',
-        'always',
+      "capitalized-comments": [
+        "warn",
+        "always",
         {
           ignoreInlineComments: true,
           ignoreConsecutiveComments: true,
         },
       ],
-      curly: ['error', 'multi-line', 'consistent'],
-      'import/order': [
-        'error',
+      curly: ["error", "multi-line", "consistent"],
+      "import/order": [
+        "error",
         {
           groups: [
-            'type',
-            'builtin',
-            'external',
-            'internal',
-            'index',
-            'sibling',
-            'parent',
-            'object',
+            "type",
+            "builtin",
+            "external",
+            "internal",
+            "index",
+            "sibling",
+            "parent",
+            "object",
           ],
           pathGroups: [
             {
-              pattern: '@',
-              group: 'internal',
+              pattern: "@",
+              group: "internal",
             },
             {
-              pattern: '@/**',
-              group: 'internal',
+              pattern: "@/**",
+              group: "internal",
             },
           ],
-          pathGroupsExcludedImportTypes: ['type'],
-          'newlines-between': 'never',
+          pathGroupsExcludedImportTypes: ["type"],
+          "newlines-between": "never",
         },
       ],
-      '@typescript-eslint/no-require-imports': 0,
-      '@typescript-eslint/no-namespace': 0,
-      '@typescript-eslint/no-explicit-any': 0,
-      '@typescript-eslint/explicit-module-boundary-types': 0,
-      '@typescript-eslint/no-unused-vars': [
-        'warn',
+      "@typescript-eslint/no-require-imports": 0,
+      "@typescript-eslint/no-namespace": 0,
+      "@typescript-eslint/no-explicit-any": 0,
+      "@typescript-eslint/explicit-module-boundary-types": 0,
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
         {
-          varsIgnorePattern: '^_',
-          argsIgnorePattern: '^_',
+          varsIgnorePattern: "^_",
+          argsIgnorePattern: "^_",
         },
       ],
-      '@typescript-eslint/no-inferrable-types': 0,
-      '@typescript-eslint/no-non-null-assertion': 0,
-      '@typescript-eslint/no-this-alias': 0,
-      '@typescript-eslint/no-var-requires': 0,
-      '@typescript-eslint/no-empty-function': 0,
-      '@typescript-eslint/no-empty-interface': 0,
-      '@typescript-eslint/consistent-type-imports': ['error'],
-      '@typescript-eslint/consistent-type-exports': ['error'],
-      'no-throw-literal': 'off',
-      '@typescript-eslint/no-throw-literal': 'off',
-      '@typescript-eslint/naming-convention': [
-        'error',
+      "@typescript-eslint/no-inferrable-types": 0,
+      "@typescript-eslint/no-non-null-assertion": 0,
+      "@typescript-eslint/no-this-alias": 0,
+      "@typescript-eslint/no-var-requires": 0,
+      "@typescript-eslint/no-empty-function": 0,
+      "@typescript-eslint/no-empty-interface": 0,
+      "@typescript-eslint/consistent-type-imports": ["error"],
+      "@typescript-eslint/consistent-type-exports": ["error"],
+      "no-throw-literal": "off",
+      "@typescript-eslint/no-throw-literal": "off",
+      "@typescript-eslint/naming-convention": [
+        "error",
         {
-          selector: 'function',
-          format: ['camelCase', 'PascalCase'],
-          leadingUnderscore: 'allow',
-          trailingUnderscore: 'allowSingleOrDouble',
+          selector: "function",
+          format: ["camelCase", "PascalCase"],
+          leadingUnderscore: "allow",
+          trailingUnderscore: "allowSingleOrDouble",
         },
         {
-          selector: 'variable',
-          format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
-          leadingUnderscore: 'allow',
-          trailingUnderscore: 'allowSingleOrDouble',
+          selector: "variable",
+          format: ["camelCase", "UPPER_CASE", "PascalCase"],
+          leadingUnderscore: "allow",
+          trailingUnderscore: "allowSingleOrDouble",
         },
         {
-          selector: 'parameter',
-          format: ['camelCase'],
-          leadingUnderscore: 'allow',
-          trailingUnderscore: 'allowSingleOrDouble',
+          selector: "parameter",
+          format: ["camelCase"],
+          leadingUnderscore: "allow",
+          trailingUnderscore: "allowSingleOrDouble",
         },
         {
-          selector: 'typeLike',
-          format: ['PascalCase'],
-          trailingUnderscore: 'allowSingleOrDouble',
+          selector: "typeLike",
+          format: ["PascalCase"],
+          trailingUnderscore: "allowSingleOrDouble",
         },
         {
-          selector: 'enumMember',
-          format: ['PascalCase', 'UPPER_CASE'],
+          selector: "enumMember",
+          format: ["PascalCase", "UPPER_CASE"],
         },
         {
-          selector: 'objectLiteralProperty',
+          selector: "objectLiteralProperty",
           format: null,
         },
         {
-          selector: 'typeProperty',
+          selector: "typeProperty",
           format: null,
         },
       ],
-      '@typescript-eslint/ban-ts-comment': [
-        'error',
+      "@typescript-eslint/ban-ts-comment": [
+        "error",
         {
-          'ts-ignore': 'allow-with-description',
+          "ts-ignore": "allow-with-description",
         },
       ],
     },

--- a/src/configs/prettier.config.mjs
+++ b/src/configs/prettier.config.mjs
@@ -1,0 +1,14 @@
+/** @type {import('prettier').Config} */
+export const semi = true;
+export const trailingComma = "all";
+export const singleQuote = true;
+export const printWidth = 80;
+export const tabWidth = 2;
+export const useTabs = false;
+export const endOfLine = "lf";
+export const overrides = [
+  {
+    files: ["*.md", "*.mdx"],
+    options: { proseWrap: "always" },
+  },
+];


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
This PR implements a local `prettier.config.mjs` which js-lint will use for its prettier instead of the target repo's `.prettier.rc`.


### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #27 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [ ] 1. Make js-lint use local `prettier.config.mjs` instead of target repo's `.prettierc`

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
